### PR TITLE
Lag global exception-handler for ressurs + metrikk for http-kall

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
         <javax.ws.rs.version>2.0.1</javax.ws.rs.version>
         <jersey-common.version>2.26</jersey-common.version>
         <logstash-logback-encoder.version>4.10</logstash-logback-encoder.version>
-        <prometheus.version>0.3.0</prometheus.version>
         <micrometer-registry-prometheus.version>1.0.6</micrometer-registry-prometheus.version>
         <cxf.version>3.2.0</cxf.version>
         <oidc-spring-support.version>0.2.12</oidc-spring-support.version>
@@ -53,7 +52,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
-        
+
         <!-- REST utils -->
         <dependency>
             <groupId>javax.ws.rs</groupId>
@@ -113,6 +112,13 @@
             <artifactId>oidc-test-support</artifactId>
             <version>${oidc-spring-support.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <!-- METRICS -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>${micrometer-registry-prometheus.version}</version>
         </dependency>
 
         <!-- SOAP w/CXF -->

--- a/src/main/java/no/nav/syfo/exception/ApiError.java
+++ b/src/main/java/no/nav/syfo/exception/ApiError.java
@@ -1,0 +1,15 @@
+package no.nav.syfo.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiError {
+    private int status;
+    private String message;
+
+    public ApiError(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}
+

--- a/src/main/java/no/nav/syfo/exception/ControllerExceptionHandler.java
+++ b/src/main/java/no/nav/syfo/exception/ControllerExceptionHandler.java
@@ -1,0 +1,72 @@
+package no.nav.syfo.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import no.nav.security.spring.oidc.validation.interceptor.OIDCUnauthorizedException;
+import no.nav.syfo.metric.Metric;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.util.WebUtils;
+
+import javax.inject.Inject;
+
+@Slf4j
+@ControllerAdvice
+public class ControllerExceptionHandler {
+
+    private final String BAD_REQUEST_MSG = "Vi kunne ikke tolke inndataene";
+    private final String INTERNAL_MSG = "Det skjedde en uventet feil";
+    private final String UNAUTHORIZED_MSG = "Autorisasjonsfeil";
+
+    private Metric metric;
+
+    @Inject
+    public ControllerExceptionHandler(Metric metric) {
+        this.metric = metric;
+    }
+
+    @ExceptionHandler({
+            Exception.class,
+            IllegalArgumentException.class,
+    })
+    public final ResponseEntity<ApiError> handleException(Exception ex, WebRequest request) {
+        HttpHeaders headers = new HttpHeaders();
+
+        if (ex instanceof OIDCUnauthorizedException) {
+            OIDCUnauthorizedException notAuthorizedException = (OIDCUnauthorizedException) ex;
+
+            return handleOIDCUnauthorizedException(notAuthorizedException, headers, request);
+        } else if (ex instanceof IllegalArgumentException) {
+            IllegalArgumentException illegalArgumentException = (IllegalArgumentException) ex;
+
+            return handleIllegalArgumentException(illegalArgumentException, headers, request);
+        } else {
+            HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+
+            return handleExceptionInternal(ex, new ApiError(status.value(), INTERNAL_MSG), headers, status, request);
+        }
+    }
+
+    private ResponseEntity<ApiError> handleOIDCUnauthorizedException(OIDCUnauthorizedException ex, HttpHeaders headers, WebRequest request) {
+        HttpStatus status = HttpStatus.UNAUTHORIZED;
+        return handleExceptionInternal(ex, new ApiError(status.value(), UNAUTHORIZED_MSG), headers, status, request);
+    }
+
+    private ResponseEntity<ApiError> handleIllegalArgumentException(IllegalArgumentException ex, HttpHeaders headers, WebRequest request) {
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        return handleExceptionInternal(ex, new ApiError(status.value(), BAD_REQUEST_MSG), headers, status, request);
+    }
+
+    private ResponseEntity<ApiError> handleExceptionInternal(Exception ex, ApiError body, HttpHeaders headers, HttpStatus status, WebRequest request) {
+        metric.tellHttpKall(status.value());
+
+        if (HttpStatus.INTERNAL_SERVER_ERROR.equals(status)) {
+            request.setAttribute(WebUtils.ERROR_EXCEPTION_ATTRIBUTE, ex, WebRequest.SCOPE_REQUEST);
+        }
+
+        return new ResponseEntity<>(body, headers, status);
+    }
+}

--- a/src/main/java/no/nav/syfo/metric/Metric.java
+++ b/src/main/java/no/nav/syfo/metric/Metric.java
@@ -1,0 +1,33 @@
+package no.nav.syfo.metric;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import org.springframework.stereotype.Controller;
+
+import javax.inject.Inject;
+
+@Controller
+public class Metric {
+
+    private final MeterRegistry registry;
+
+    @Inject
+    public Metric(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    public void tellHttpKall(int kode) {
+        registry.counter(
+                addPrefix("httpstatus"),
+                Tags.of(
+                        "type", "info",
+                        "kode", String.valueOf(kode)
+                )
+        ).increment();
+    }
+
+    private String addPrefix(String navn) {
+        String METRIKK_PREFIX = "syfotilgangskontroll_";
+        return METRIKK_PREFIX + navn;
+    }
+}


### PR DESCRIPTION
- Legger til global haandtering av exeptions for alle controller. Denne haandterer nå 5xx-feil, 401 og 400.
- Tell antall http-kall som feiler med Prometheus som da tilgjengeliggjøres til Grafana.