### PR TITLE
Get Behandlendeenhet when Geografisk Tilknytning is country code

### DIFF
--- a/naiserator-dev.yaml
+++ b/naiserator-dev.yaml
@@ -74,3 +74,7 @@ spec:
       value: dc=preprod,dc=local
     - name: NORG2_URL
       value: https://app-q1.adeo.no/norg2
+    - name: SECURITY_TOKEN_SERVICE_REST_URL
+      value: https://security-token-service.nais.preprod.local
+    - name: SYFOBEHANDLENDEENHET_URL
+      value: https://syfobehandlendeenhet.nais.preprod.local

--- a/naiserator-prod.yaml
+++ b/naiserator-prod.yaml
@@ -74,3 +74,7 @@ spec:
       value: dc=adeo,dc=no
     - name: NORG2_URL
       value: https://app.adeo.no/norg2
+    - name: SECURITY_TOKEN_SERVICE_REST_URL
+      value: https://security-token-service.nais.adeo.no
+    - name: SYFOBEHANDLENDEENHET_URL
+      value: https://syfobehandlendeenhet.nais.adeo.no

--- a/src/main/java/no/nav/syfo/config/CacheConfig.java
+++ b/src/main/java/no/nav/syfo/config/CacheConfig.java
@@ -20,6 +20,7 @@ public class CacheConfig {
     public static final String TILGANGTILTJENESTEN = "tilgangtiltjenesten";
     public static final String TILGANGTILENHET = "tilgangtilenhet";
     public static final String CACHENAME_AXSYS_ENHETER = "axsysenheter";
+    public static final String CACHENAME_BEHANDLENDEENHET_FNR = "behandlendeenhetfnr";
     public static final String CACHENAME_EGENANSATT = "egenansatt";
     public static final String CACHENAME_ENHET_OVERORDNET_ENHETER = "enhetoverordnetenheter";
     public static final String CACHENAME_GEOGRAFISK_TILHORIGHET_ENHET = "geografisktilhorighetenhet";
@@ -39,6 +40,7 @@ public class CacheConfig {
         cacheConfigurations.put(TILGANGTILTJENESTEN, defaultConfig);
         cacheConfigurations.put(TILGANGTILENHET, defaultConfig);
         cacheConfigurations.put(CACHENAME_AXSYS_ENHETER, defaultConfig);
+        cacheConfigurations.put(CACHENAME_BEHANDLENDEENHET_FNR, defaultConfig);
         cacheConfigurations.put(CACHENAME_EGENANSATT, defaultConfig);
         cacheConfigurations.put(CACHENAME_ENHET_OVERORDNET_ENHETER, defaultConfig);
         cacheConfigurations.put(CACHENAME_GEOGRAFISK_TILHORIGHET_ENHET, defaultConfig);

--- a/src/main/java/no/nav/syfo/services/TilgangService.java
+++ b/src/main/java/no/nav/syfo/services/TilgangService.java
@@ -52,7 +52,7 @@ public class TilgangService {
             return new Tilgang().withHarTilgang(false).withBegrunnelse(SYFO.name());
         }
 
-        if (!geografiskTilgangService.harGeografiskTilgang(veilederId, personInfo.getGeografiskTilknytning())) {
+        if (!geografiskTilgangService.harGeografiskTilgang(veilederId, brukerFnr, personInfo.getGeografiskTilknytning())) {
             return new Tilgang().withHarTilgang(false).withBegrunnelse(GEOGRAFISK);
         }
 

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/BehandlendeEnhet.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/BehandlendeEnhet.kt
@@ -1,0 +1,8 @@
+package no.nav.syfo.behandlendeenhet
+
+import java.io.Serializable
+
+data class BehandlendeEnhet(
+    val enhetId: String,
+    val navn: String
+) : Serializable

--- a/src/main/kotlin/no/nav/syfo/behandlendeenhet/BehandlendeEnhetConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/behandlendeenhet/BehandlendeEnhetConsumer.kt
@@ -1,0 +1,62 @@
+package no.nav.syfo.behandlendeenhet
+
+import no.nav.syfo.config.CacheConfig
+import no.nav.syfo.metric.Metric
+import no.nav.syfo.sts.StsConsumer
+import no.nav.syfo.util.*
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.http.*
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestClientResponseException
+import org.springframework.web.client.RestTemplate
+
+@Service
+class BehandlendeEnhetConsumer(
+    @Value("\${syfobehandlendeenhet.url}") private val baseUrl: String,
+    private val metric: Metric,
+    private val stsConsumer: StsConsumer,
+    private val template: RestTemplate
+) {
+
+    @Cacheable(cacheNames = [CacheConfig.CACHENAME_BEHANDLENDEENHET_FNR], key = "#fnr", condition = "#fnr != null")
+    fun getBehandlendeEnhet(fnr: String, callId: String?): BehandlendeEnhet {
+        val stsToken = stsConsumer.token()
+
+        val httpEntity = entity(callId, stsToken)
+        try {
+            val response = template.exchange<BehandlendeEnhet>(
+                getBehandlendeEnhetUrl(fnr),
+                HttpMethod.GET,
+                httpEntity,
+                BehandlendeEnhet::class.java
+            )
+            val responseBody = response.body!!
+            metric.countEvent(METRIC_CALL_BEHANDLENDEENHET_SUCCESS)
+            return responseBody
+        } catch (e: RestClientResponseException) {
+            LOG.error("Error requesting BehandlendeEnhet from syfobehandlendeenhet with callId ${httpEntity.headers[NAV_CALL_ID_HEADER]}: ", e)
+            metric.countEvent(METRIC_CALL_BEHANDLENDEENHET_FAIL)
+            throw e
+        }
+    }
+
+    private fun getBehandlendeEnhetUrl(bruker: String) = "$baseUrl/api/$bruker"
+
+    private fun entity(callId: String?, token: String): HttpEntity<String> {
+        val credentials = bearerCredentials(token)
+        val headers = HttpHeaders()
+        headers[HttpHeaders.AUTHORIZATION] = credentials
+        headers[NAV_CALL_ID_HEADER] = getOrCreateCallId(callId)
+        headers[NAV_CONSUMER_ID_HEADER] = APP_CONSUMER_ID
+        return HttpEntity(headers)
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(BehandlendeEnhetConsumer::class.java)
+
+        const val METRIC_CALL_BEHANDLENDEENHET_SUCCESS = "call_behandlendeenhet_success"
+        const val METRIC_CALL_BEHANDLENDEENHET_FAIL = "call_behandlendeenhet_fail"
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/sts/StsConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/sts/StsConsumer.kt
@@ -1,0 +1,83 @@
+package no.nav.syfo.sts
+
+import no.nav.syfo.metric.Metric
+import no.nav.syfo.util.basicCredentials
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.*
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestClientResponseException
+import org.springframework.web.client.RestTemplate
+import java.time.LocalDateTime
+
+@Service
+class StsConsumer(
+    private val metric: Metric,
+    @Value("\${security.token.service.rest.url}") private val baseUrl: String,
+    @Value("\${srv.username}") private val username: String,
+    @Value("\${srv.password}") private val password: String,
+    private val template: RestTemplate
+) {
+    private var cachedOidcToken: STSToken? = null
+
+    fun token(): String {
+        if (STSToken.shouldRenew(cachedOidcToken)) {
+            val request = HttpEntity<Any>(authorizationHeader())
+
+            try {
+                val response = template.exchange<STSToken>(
+                    getStsTokenUrl(),
+                    HttpMethod.GET,
+                    request,
+                    STSToken::class.java
+                )
+                cachedOidcToken = response.body
+                metric.countEvent(METRIC_CALL_STS_SUCCESS)
+            } catch (e: RestClientResponseException) {
+                LOG.error("Request to get STS failed with status: ${e.rawStatusCode} and message: ${e.responseBodyAsString}")
+                metric.countEvent(METRIC_CALL_STS_FAIL)
+                throw e
+            }
+        }
+
+        return cachedOidcToken!!.access_token
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(StsConsumer::class.java)
+
+        const val METRIC_CALL_STS_SUCCESS = "call_sts_success"
+        const val METRIC_CALL_STS_FAIL = "call_sts_fail"
+    }
+
+    private fun getStsTokenUrl() = "$baseUrl/rest/v1/sts/token?grant_type=client_credentials&scope=openid"
+
+    private fun authorizationHeader(): HttpHeaders {
+        val credentials = basicCredentials(username, password)
+        val headers = HttpHeaders()
+        headers.add(HttpHeaders.AUTHORIZATION, credentials)
+        return headers
+    }
+}
+
+data class STSToken(
+    val access_token: String,
+    val token_type: String,
+    val expires_in: Int
+) {
+    val expirationTime: LocalDateTime = LocalDateTime.now().plusSeconds(expires_in - 10L)
+
+    companion object {
+        fun shouldRenew(token: STSToken?): Boolean {
+            if (token == null) {
+                return true
+            }
+
+            return isExpired(token)
+        }
+
+        private fun isExpired(token: STSToken): Boolean {
+            return token.expirationTime.isBefore(LocalDateTime.now())
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/util/CredentialUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/CredentialUtil.kt
@@ -5,3 +5,5 @@ import java.util.*
 fun basicCredentials(credentialUsername: String, credentialPassword: String): String {
     return "Basic " + Base64.getEncoder().encodeToString(java.lang.String.format("%s:%s", credentialUsername, credentialPassword).toByteArray())
 }
+
+fun bearerCredentials(token: String) = "Bearer $token"

--- a/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/RequestUtil.kt
@@ -7,3 +7,5 @@ const val APP_CONSUMER_ID = "syfo-tilgangskontroll"
 const val NAV_CALL_ID_HEADER = "Nav-Call-Id"
 
 fun createCallId(): String = UUID.randomUUID().toString()
+
+fun getOrCreateCallId(callId: String?): String = callId ?: UUID.randomUUID().toString()

--- a/src/test/kotlin/no/nav/syfo/testhelper/BehandlendeenhetMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/BehandlendeenhetMock.kt
@@ -1,0 +1,10 @@
+package no.nav.syfo.testhelper
+
+import no.nav.syfo.behandlendeenhet.BehandlendeEnhet
+
+fun generateBehandlendeEnhet(enhetNr: String = ENHET_NR): BehandlendeEnhet {
+    return BehandlendeEnhet(
+        enhetId = enhetNr,
+        navn = ENHET_NAVN
+    )
+}

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -7,4 +7,6 @@ object UserConstants {
     const val NAV_ENHETID_1 = "0330"
     const val NAV_ENHETID_2 = "1814"
     const val NAV_ENHETID_3 = "0215"
+
+    const val PERSON_FNR = "12345678910"
 }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -20,4 +20,10 @@ server:
   servlet:
     context-path: /syfo-tilgangskontroll
 
+srv:
+  username: "username"
+  password: "password"
+
 norg2.url: http://norg2/norg2
+security.token.service.rest.url: "http://security-token-service"
+syfobehandlendeenhet.url: "http://syfobehandlendeenhet"


### PR DESCRIPTION
Norg2 doesnt return any Enhet when requesting NAVKontorForGT(http 404) and a runtimeexception is therefore thrown and returned to user. To solve this issue, we will get enhet from syfobehandlendeenhet when Geografisk Tilknytning corresponds to a country code, e.g. NOR/SWE/FIN. Where Geografisk Tilknytning is a country code, the codes represents country where the person is residing og originating from. For this group of users, syfobehandlendeenhet will probably return eneht 0393 NAV Oppfolging Utland for all users.