### PR TITLE
Add access to Kode6-user for consumer Smregistrering

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -60,6 +60,8 @@ spec:
       value: "true"
     - name: AAD_TENANT_ID
       value: 966ac572-f5b7-4bbe-aa88-c76419c0f851
+    - name: SMREGISTRERING_CLIENT_ID
+      value: "6e2c2c7d-9bc1-45f9-a76c-9d32b489268a"
     - name: NO_NAV_SECURITY_JWT_ISSUER_VEILEDER_DISCOVERYURL
       value: https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/.well-known/openid-configuration
     - name: NO_NAV_SECURITY_JWT_ISSUER_VEILEDER_ACCEPTEDAUDIENCE

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -60,6 +60,8 @@ spec:
       value: "true"
     - name: AAD_TENANT_ID
       value: 62366534-1ec3-4962-8869-9b5535279d0b
+    - name: SMREGISTRERING_CLIENT_ID
+      value: "88adf8ed-fed1-4022-bbc6-da222e4795eb"
     - name: NO_NAV_SECURITY_JWT_ISSUER_VEILEDER_DISCOVERYURL
       value: https://login.microsoftonline.com/navno.onmicrosoft.com/.well-known/openid-configuration
     - name: NO_NAV_SECURITY_JWT_ISSUER_VEILEDER_ACCEPTEDAUDIENCE

--- a/src/main/kotlin/no/nav/syfo/api/auth/OIDCUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/api/auth/OIDCUtil.kt
@@ -13,4 +13,9 @@ object OIDCUtil {
     fun getTokenFromAzureOIDCToken(contextHolder: TokenValidationContextHolder): String {
         return contextHolder.tokenValidationContext.getJwtToken(OIDCIssuer.VEILEDERAZURE).tokenAsString
     }
+
+    @JvmStatic
+    fun getConsumerClientId(contextHolder: TokenValidationContextHolder): String {
+        return contextHolder.tokenValidationContext.getClaims(OIDCIssuer.VEILEDERAZURE).getStringClaim("azp")
+    }
 }

--- a/src/main/kotlin/no/nav/syfo/tilgang/Kode6TilgangService.kt
+++ b/src/main/kotlin/no/nav/syfo/tilgang/Kode6TilgangService.kt
@@ -1,0 +1,29 @@
+package no.nav.syfo.tilgang
+
+import no.nav.syfo.consumer.ldap.LdapService
+import no.nav.syfo.domain.AdRoller
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+
+@Service
+class Kode6TilgangService(
+    @Value("\${smregistrering.client.id}") private val smregisteringClientId: String,
+    private val ldapService: LdapService,
+) {
+    private var kode6TjenesteList = listOf(smregisteringClientId)
+
+    fun harTilgang(
+        consumerClientId: String,
+        veilederId: String
+    ): Boolean {
+        return harTjenesteTilgang(consumerClientId) && harVeilederTilgang(veilederId)
+    }
+
+    private fun harTjenesteTilgang(consumerClientId: String): Boolean {
+        return kode6TjenesteList.contains(consumerClientId)
+    }
+
+    private fun harVeilederTilgang(veilederId: String): Boolean {
+        return ldapService.harTilgang(veilederId, AdRoller.KODE6.rolle)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/tilgang/TilgangController.kt
+++ b/src/main/kotlin/no/nav/syfo/tilgang/TilgangController.kt
@@ -6,6 +6,7 @@ import no.nav.syfo.metric.Metric
 import no.nav.syfo.api.auth.OIDCClaim.NAVIDENT
 import no.nav.syfo.api.auth.OIDCIssuer.AZURE
 import no.nav.syfo.api.auth.OIDCIssuer.VEILEDERAZURE
+import no.nav.syfo.api.auth.OIDCUtil.getConsumerClientId
 import no.nav.syfo.api.auth.OIDCUtil.getSubjectFromAzureOIDCToken
 import no.nav.syfo.api.auth.OIDCUtil.getTokenFromAzureOIDCToken
 import no.nav.syfo.consumer.msgraph.TokenConsumer
@@ -66,7 +67,8 @@ class TilgangController @Autowired constructor(
     @ProtectedWithClaims(issuer = VEILEDERAZURE)
     fun accessToPersonViaAzure(@PathVariable fnr: String): ResponseEntity<*> {
         val veilederId = tokenConsumer.getSubjectFromMsGraph(getTokenFromAzureOIDCToken(contextHolder))
-        return sjekktilgangTilBruker(veilederId, fnr)
+        val consumerClientId = getConsumerClientId(contextHolder)
+        return sjekktilgangTilBruker(veilederId, fnr, consumerClientId)
     }
 
     private fun sjekkTilgangTilTjenesten(veilederId: String): ResponseEntity<*> {
@@ -74,8 +76,12 @@ class TilgangController @Autowired constructor(
         return lagRespons(tilgang)
     }
 
-    private fun sjekktilgangTilBruker(veilederId: String, fnr: String): ResponseEntity<*> {
-        val tilgang = tilgangService.sjekkTilgangTilBruker(veilederId, fnr)
+    private fun sjekktilgangTilBruker(
+        veilederId: String,
+        fnr: String,
+        consumerClientId: String = ""
+    ): ResponseEntity<*> {
+        val tilgang = tilgangService.sjekkTilgangTilBruker(veilederId, fnr, consumerClientId)
         return lagRespons(tilgang)
     }
 

--- a/src/test/kotlin/no/nav/syfo/testhelper/OidcTestHelper.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/OidcTestHelper.kt
@@ -21,8 +21,12 @@ object OidcTestHelper {
 
     @JvmStatic
     @Throws(ParseException::class)
-    fun logInVeilederWithAzure2(oidcRequestContextHolder: TokenValidationContextHolder, veilederIdent: String?) {
-        val claimsSet = JWTClaimsSet.parse("{ }")
+    fun logInVeilederWithAzure2(
+        oidcRequestContextHolder: TokenValidationContextHolder,
+        consumerClientId: String = "",
+        veilederIdent: String?
+    ) {
+        val claimsSet = JWTClaimsSet.parse("{ \"azp\": \"$consumerClientId\" }")
         val jwt = JwtTokenGenerator.createSignedJWT(claimsSet)
         settOIDCValidationContext(oidcRequestContextHolder, jwt, VEILEDERAZURE)
     }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -24,6 +24,8 @@ srv:
   username: "username"
   password: "password"
 
+smregistrering.client.id: "smregistrering"
+
 norg2.url: http://norg2/norg2
 pdl.url: "http://pdl"
 security.token.service.rest.url: "http://security-token-service"


### PR DESCRIPTION
The consumer Smregistrering should be granted to Kode6-users and a service to handle access to Kode6-users by filtering the consumer client id is therefore added.