### PR TITLE
Remove ispengestopp fss from acces policy

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -51,9 +51,6 @@ spec:
         - application: ispengestopp
           namespace: teamsykefravr
           cluster: dev-gcp
-        - application: ispengestopp
-          namespace: teamsykefravr
-          cluster: dev-fss
         - application: ispersonoppgave
           namespace: teamsykefravr
           cluster: dev-fss

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -51,9 +51,6 @@ spec:
         - application: ispengestopp
           namespace: teamsykefravr
           cluster: prod-gcp
-        - application: ispengestopp
-          namespace: teamsykefravr
-          cluster: prod-fss
         - application: ispersonoppgave
           namespace: teamsykefravr
           cluster: prod-fss


### PR DESCRIPTION
Ispengestopp no longer exists in Fss, only in GCP, and access policy for FSS is therefore removed.