### PR TITLE
Add new endpoint with Tilgangskontroll for Papirsykmelding and

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -156,3 +156,5 @@ spec:
       value: "d2987104-63b2-4110-83ac-20ff6afe24a2" # 0000-GA-GOSYS_REGIONAL
     - name: ROLE_UTVIDBAR_REGIONAL_ID
       value: "a5c2370e-6b3d-4c2c-9a5e-238008526574" # 0000-GA-GOSYS_UTVIDBAR_TIL_REGIONAL
+    - name: ROLE_PAPIRSYKMELDING_ID
+      value: "16aff429-1efc-402a-ae12-4000633d0063" # 0000-GA-papirsykmelding

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -156,3 +156,5 @@ spec:
       value: "422852aa-aad5-4601-a8c8-917ef42b6601" # 0000-GA-GOSYS_REGIONAL
     - name: ROLE_UTVIDBAR_REGIONAL_ID
       value: "14caf09e-dd9a-43fe-b25e-7f58dd9fdcae" # 0000-GA-GOSYS_UTVIDBAR_TIL_REGIONAL
+    - name: ROLE_PAPIRSYKMELDING_ID
+      value: "dfde2123-1969-4cd2-8977-bdf19721e76d" # 0000-GA-papirsykmelding

--- a/src/main/kotlin/no/nav/syfo/api/auth/OIDCUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/api/auth/OIDCUtil.kt
@@ -6,6 +6,7 @@ object OIDCUtil {
     @JvmStatic
     fun getConsumerClientId(contextHolder: TokenValidationContextHolder): String {
         return contextHolder.tokenValidationContext.getClaims(OIDCIssuer.VEILEDERAZURE).getStringClaim("azp")
+            ?: throw IllegalArgumentException("Claim AZP was not found in token")
     }
 }
 

--- a/src/main/kotlin/no/nav/syfo/cache/CacheConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/cache/CacheConfig.kt
@@ -37,7 +37,7 @@ class CacheConfig {
             .entryTtl(Duration.ofHours(12L))
 
         cacheConfigurations[TILGANGTILBRUKER] = defaultConfig
-        cacheConfigurations[TILGANGTILTJENESTEN] = defaultConfig
+        cacheConfigurations[TILGANGTILBRUKER_PAPIRSYKMELDING] = defaultConfig
         cacheConfigurations[TILGANGTILENHET] = defaultConfig
         cacheConfigurations[CACHENAME_AXSYS_ENHETER] = defaultConfig
         cacheConfigurations[CACHENAME_BEHANDLENDEENHET_FNR] = defaultConfig
@@ -59,6 +59,7 @@ class CacheConfig {
 
     companion object {
         const val TILGANGTILBRUKER = "tilgangbruker"
+        const val TILGANGTILBRUKER_PAPIRSYKMELDING = "tilgangbrukerpapirsykmelding"
         const val TILGANGTILTJENESTEN = "tilgangtjenesten"
         const val TILGANGTILENHET = "tilgangenhet"
         const val CACHENAME_AXSYS_ENHETER = "axsysenheter"

--- a/src/main/kotlin/no/nav/syfo/domain/AdRoller.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/AdRoller.kt
@@ -19,6 +19,7 @@ class AdRoller(
     @Value("\${role.utvidbar.nasjonal.id}") val utvidbarNasjonalId: String,
     @Value("\${role.regional.id}") val regionalId: String,
     @Value("\${role.utvidbar.regional.id}") val utvidvarRegionalId: String,
+    @Value("\${role.papirsykmelding.id}") val papirsykmeldingId: String,
 ) {
     val KODE6 = AdRolle(
         name = "KODE6",
@@ -59,5 +60,10 @@ class AdRoller(
         name = "UTVIDBAR_TIL_REGIONAL",
         id = utvidvarRegionalId,
         rolle = "0000-GA-GOSYS_UTVIDBAR_TIL_REGIONAL",
+    )
+    val PAPIRSYKMELDING = AdRolle(
+        name = "PAPIRSYKMELDING",
+        id = papirsykmeldingId,
+        rolle = "0000-GA-papirsykmelding",
     )
 }

--- a/src/main/kotlin/no/nav/syfo/tilgang/APIConsumerAccessService.kt
+++ b/src/main/kotlin/no/nav/syfo/tilgang/APIConsumerAccessService.kt
@@ -1,17 +1,29 @@
 package no.nav.syfo.tilgang
 
 import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.security.token.support.core.context.TokenValidationContextHolder
+import no.nav.syfo.api.auth.OIDCUtil.getConsumerClientId
 import no.nav.syfo.util.configuredJacksonMapper
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 
 @Service
 class APIConsumerAccessService(
-    @Value("\${AZURE_APP_PRE_AUTHORIZED_APPS}") private val azureAppPreAuthorizedApp: String,
+    private val tokenValidationContextHolder: TokenValidationContextHolder,
+    @Value("\${azure.app.pre.authorized.apps}") private val azureAppPreAuthorizedApps: String,
 ) {
     private val preAuthorizedClientList: List<PreAuthorizedClient> = configuredJacksonMapper()
-        .readValue(azureAppPreAuthorizedApp)
+        .readValue(azureAppPreAuthorizedApps)
 
     fun getAuthorizedAppNameFromClientId(clientId: String): String =
         preAuthorizedClientList.find { it.clientId == clientId }?.toNamespaceAndApplicationName()?.applicationName ?: ""
+
+    fun isConsumerApplicationAZPAuthorized(authorizedApplicationNameList: List<String>): Boolean {
+        val clientIdList = preAuthorizedClientList
+            .filter { authorizedApplicationNameList.contains(it.toNamespaceAndApplicationName().applicationName) }
+            .map { it.clientId }
+
+        val consumerClientIdAzp = getConsumerClientId(contextHolder = tokenValidationContextHolder)
+        return clientIdList.contains(consumerClientIdAzp)
+    }
 }

--- a/src/main/kotlin/no/nav/syfo/tilgang/PapirsykmeldingTilgangService.kt
+++ b/src/main/kotlin/no/nav/syfo/tilgang/PapirsykmeldingTilgangService.kt
@@ -1,0 +1,34 @@
+package no.nav.syfo.tilgang
+
+import io.micrometer.core.annotation.Timed
+import no.nav.syfo.consumer.graphapi.GraphApiConsumer
+import no.nav.syfo.domain.AdRoller
+import org.springframework.stereotype.Service
+
+@Service
+class PapirsykmeldingTilgangService(
+    private val adRoller: AdRoller,
+    private val apiConsumerAccessService: APIConsumerAccessService,
+    private val graphApiConsumer: GraphApiConsumer,
+) {
+    @Timed("syfotilgangskontroll_papirsykmelding_harTilgang", histogram = true)
+    fun harPapirsykmeldingTilgang(
+        veilederIdent: String,
+    ): Boolean {
+        val isConsumerApplicationAuthorized = apiConsumerAccessService.isConsumerApplicationAZPAuthorized(
+            authorizedApplicationNameList = authorizedConsumerApplicationNameList,
+        )
+        val isConsumerVeilederIdentAuthorized = graphApiConsumer.hasAccess(
+            adRolle = adRoller.PAPIRSYKMELDING,
+            veilederIdent = veilederIdent,
+        )
+        return isConsumerApplicationAuthorized && isConsumerVeilederIdentAuthorized
+    }
+
+    companion object {
+        private const val SMREGISTRERING_BACKEND_NAME = "smregistrering-backend"
+        val authorizedConsumerApplicationNameList = listOf(
+            SMREGISTRERING_BACKEND_NAME,
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/api/PapirsykmeldingTilgangTest.kt
+++ b/src/test/kotlin/no/nav/syfo/api/PapirsykmeldingTilgangTest.kt
@@ -1,0 +1,283 @@
+package no.nav.syfo.api
+
+import no.nav.security.token.support.core.context.TokenValidationContextHolder
+import no.nav.syfo.LocalApplication
+import no.nav.syfo.consumer.axsys.AxsysConsumer
+import no.nav.syfo.consumer.axsys.AxsysEnhet
+import no.nav.syfo.consumer.graphapi.GraphApiConsumer
+import no.nav.syfo.consumer.norg2.NorgConsumer
+import no.nav.syfo.consumer.pdl.*
+import no.nav.syfo.consumer.skjermedepersoner.SkjermedePersonerPipConsumer
+import no.nav.syfo.domain.AdRoller
+import no.nav.syfo.testhelper.GraphApiUtil.mockAdRolle
+import no.nav.syfo.testhelper.OidcTestHelper.logInVeilederWithAzure2
+import no.nav.syfo.testhelper.OidcTestHelper.loggUtAlle
+import no.nav.syfo.testhelper.UserConstants.BENGT_KODE6_BRUKER
+import no.nav.syfo.testhelper.UserConstants.BIRTE_KODE7_BRUKER
+import no.nav.syfo.testhelper.UserConstants.BJARNE_BRUKER
+import no.nav.syfo.testhelper.UserConstants.ERIK_EGENANSATT_BRUKER
+import no.nav.syfo.testhelper.UserConstants.NAV_ENHETID_1
+import no.nav.syfo.testhelper.UserConstants.NAV_ENHETID_2
+import no.nav.syfo.testhelper.UserConstants.NAV_ENHET_NAVN
+import no.nav.syfo.testhelper.UserConstants.VEILEDER_ID
+import no.nav.syfo.tilgang.Tilgang
+import no.nav.syfo.tilgang.TilgangController
+import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.ResponseEntity
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.util.MultiValueMap
+import java.text.ParseException
+
+@ExtendWith(SpringExtension::class)
+@SpringBootTest(classes = [LocalApplication::class])
+class PapirsykmeldingTilgangTest {
+    @MockBean
+    private lateinit var axsysConsumer: AxsysConsumer
+
+    @MockBean
+    private lateinit var norgConsumer: NorgConsumer
+
+    @MockBean
+    private lateinit var pdlConsumer: PdlConsumer
+
+    @MockBean
+    private lateinit var skjermedePersonerPipConsumer: SkjermedePersonerPipConsumer
+
+    @Autowired
+    private lateinit var adRoller: AdRoller
+
+    @Autowired
+    private lateinit var oidcRequestContextHolder: TokenValidationContextHolder
+
+    @Autowired
+    private lateinit var graphApiConsumerMock: GraphApiConsumer
+
+    @Value("\${smregistrering.client.id}")
+    private lateinit var smregistreringClientId: String
+
+    @Autowired
+    lateinit var tilgangController: TilgangController
+
+    @BeforeEach
+    @Throws(ParseException::class)
+    fun setup() {
+        Mockito.`when`(axsysConsumer.enheter(VEILEDER_ID)).thenReturn(
+            listOf(
+                AxsysEnhet(
+                    NAV_ENHETID_1,
+                    NAV_ENHET_NAVN
+                ),
+                AxsysEnhet(
+                    NAV_ENHETID_2,
+                    NAV_ENHET_NAVN
+                )
+            )
+        )
+        Mockito.`when`(
+            norgConsumer.getNAVKontorForGT(
+                GeografiskTilknytning(
+                    type = GeografiskTilknytningType.BYDEL,
+                    value = NAV_ENHETID_1,
+                )
+            )
+        ).thenReturn(
+            NAV_ENHETID_1
+        )
+        Mockito.`when`(pdlConsumer.geografiskTilknytning(ArgumentMatchers.anyString())).thenReturn(
+            GeografiskTilknytning(
+                type = GeografiskTilknytningType.BYDEL,
+                value = "0330",
+            )
+        )
+        Mockito.`when`(skjermedePersonerPipConsumer.erSkjermet(BJARNE_BRUKER)).thenReturn(false)
+        Mockito.`when`(skjermedePersonerPipConsumer.erSkjermet(BENGT_KODE6_BRUKER)).thenReturn(false)
+        Mockito.`when`(skjermedePersonerPipConsumer.erSkjermet(BIRTE_KODE7_BRUKER)).thenReturn(false)
+        Mockito.`when`(skjermedePersonerPipConsumer.erSkjermet(ERIK_EGENANSATT_BRUKER)).thenReturn(true)
+        logInVeilederWithAzure2(oidcRequestContextHolder, smregistreringClientId, VEILEDER_ID)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        loggUtAlle(oidcRequestContextHolder)
+    }
+
+    @Test
+    fun `access to PersonIdent with Papirsykmelding granted for Smregistrering and NavIdent with rolle PAPIRSYKMELDING`() {
+        mockAdRolle(
+            graphApiConsumer = graphApiConsumerMock,
+            veilederIdent = VEILEDER_ID,
+            innvilget = INNVILG,
+            adRolleList = arrayOf(adRoller.SYFO, adRoller.PAPIRSYKMELDING),
+        )
+
+        val headers: MultiValueMap<String, String> = LinkedMultiValueMap()
+        headers.add(NAV_PERSONIDENT_HEADER, BJARNE_BRUKER)
+
+        val response = tilgangController.accessToPersonIdentWithPapirsykmelding(headers)
+        assertAccessOk(response)
+    }
+
+    @Test
+    fun `access to PersonIdent with Papirsykmelding denied if consuming application is not Smregistrering and NavIdent with rolle PAPIRSYKMELDING`() {
+        loggUtAlle(oidcRequestContextHolder)
+        logInVeilederWithAzure2(oidcRequestContextHolder, "", VEILEDER_ID)
+
+        mockAdRolle(
+            graphApiConsumer = graphApiConsumerMock,
+            veilederIdent = VEILEDER_ID,
+            innvilget = INNVILG,
+            adRolleList = arrayOf(adRoller.SYFO, adRoller.PAPIRSYKMELDING),
+        )
+
+        val headers: MultiValueMap<String, String> = LinkedMultiValueMap()
+        headers.add(NAV_PERSONIDENT_HEADER, BJARNE_BRUKER)
+
+        val response = tilgangController.accessToPersonIdentWithPapirsykmelding(headers)
+        assertAccessDenied(response, adRoller.PAPIRSYKMELDING.name)
+    }
+
+    @Test
+    fun `access to PersonIdent with Papirsykmelding denied if consuming application is Smregistrering and NavIdent without rolle PAPIRSYKMELDING`() {
+        mockAdRolle(
+            graphApiConsumer = graphApiConsumerMock,
+            veilederIdent = VEILEDER_ID,
+            innvilget = INNVILG,
+            adRolleList = arrayOf(adRoller.SYFO),
+        )
+
+        val headers: MultiValueMap<String, String> = LinkedMultiValueMap()
+        headers.add(NAV_PERSONIDENT_HEADER, BJARNE_BRUKER)
+
+        val response = tilgangController.accessToPersonIdentWithPapirsykmelding(headers)
+        assertAccessDenied(response, adRoller.PAPIRSYKMELDING.name)
+    }
+
+    @Test
+    fun `access to Kode6-personident with Papirsykmelding denied for Smregistrering and NAVIdent without rolle KODE6`() {
+        mockAdRolle(
+            graphApiConsumer = graphApiConsumerMock,
+            veilederIdent = VEILEDER_ID,
+            innvilget = INNVILG,
+            adRolleList = arrayOf(adRoller.SYFO, adRoller.PAPIRSYKMELDING),
+        )
+        Mockito.`when`(pdlConsumer.isKode6(ArgumentMatchers.any())).thenReturn(true)
+
+        val headers: MultiValueMap<String, String> = LinkedMultiValueMap()
+        headers.add(NAV_PERSONIDENT_HEADER, BENGT_KODE6_BRUKER)
+
+        val response = tilgangController.accessToPersonIdentWithPapirsykmelding(headers)
+        assertAccessDenied(response, adRoller.KODE6.name)
+    }
+
+    @Test
+    fun `access to Kode6-personident with Papirsykmelding granted for Smregistrering and NAVIdent with rolle SYFO, PAPIRSYKMELDING and KODE7`() {
+        loggUtAlle(oidcRequestContextHolder)
+        logInVeilederWithAzure2(oidcRequestContextHolder, smregistreringClientId, VEILEDER_ID)
+
+        mockAdRolle(
+            graphApiConsumer = graphApiConsumerMock,
+            veilederIdent = VEILEDER_ID,
+            innvilget = INNVILG,
+            adRolleList = arrayOf(adRoller.SYFO, adRoller.PAPIRSYKMELDING, adRoller.KODE6),
+        )
+        Mockito.`when`(pdlConsumer.isKode6(ArgumentMatchers.any())).thenReturn(true)
+
+        val headers: MultiValueMap<String, String> = LinkedMultiValueMap()
+        headers.add(NAV_PERSONIDENT_HEADER, BENGT_KODE6_BRUKER)
+
+        val response = tilgangController.accessToPersonIdentWithPapirsykmelding(headers)
+        assertAccessOk(response)
+    }
+
+    @Test
+    fun `access to Kode7-personident with Papirsykmelding denied for Smregistrering and NAVIdent without rolle KODE7`() {
+        mockAdRolle(
+            graphApiConsumer = graphApiConsumerMock,
+            veilederIdent = VEILEDER_ID,
+            innvilget = INNVILG,
+            adRolleList = arrayOf(adRoller.SYFO, adRoller.PAPIRSYKMELDING),
+        )
+        Mockito.`when`(pdlConsumer.isKode7(ArgumentMatchers.any())).thenReturn(true)
+
+        val headers: MultiValueMap<String, String> = LinkedMultiValueMap()
+        headers.add(NAV_PERSONIDENT_HEADER, BIRTE_KODE7_BRUKER)
+
+        val response = tilgangController.accessToPersonIdentWithPapirsykmelding(headers)
+        assertAccessDenied(response, adRoller.KODE7.name)
+    }
+
+    @Test
+    fun `access to Kode7-personident with Papirsykmelding granted for Smregistrering and NAVIdent with rolle SYFO, PAPIRSYKMELDING and KODE7`() {
+        mockAdRolle(
+            graphApiConsumer = graphApiConsumerMock,
+            veilederIdent = VEILEDER_ID,
+            innvilget = INNVILG,
+            adRolleList = arrayOf(adRoller.SYFO, adRoller.PAPIRSYKMELDING, adRoller.KODE7),
+        )
+
+        val headers: MultiValueMap<String, String> = LinkedMultiValueMap()
+        headers.add(NAV_PERSONIDENT_HEADER, BIRTE_KODE7_BRUKER)
+
+        val response = tilgangController.accessToPersonIdentWithPapirsykmelding(headers)
+        assertAccessOk(response)
+    }
+
+    @Test
+    fun `access to EgenAnsatt-personident with Papirsykmelding denied for Smregistrering and NAVIdent without rolle EGEN_ANSATT`() {
+        mockAdRolle(
+            graphApiConsumer = graphApiConsumerMock,
+            veilederIdent = VEILEDER_ID,
+            innvilget = INNVILG,
+            adRolleList = arrayOf(adRoller.SYFO, adRoller.PAPIRSYKMELDING),
+        )
+
+        val headers: MultiValueMap<String, String> = LinkedMultiValueMap()
+        headers.add(NAV_PERSONIDENT_HEADER, ERIK_EGENANSATT_BRUKER)
+
+        val response = tilgangController.accessToPersonIdentWithPapirsykmelding(headers)
+        assertAccessDenied(response, adRoller.EGEN_ANSATT.name)
+    }
+
+    @Test
+    fun `access to EgenAnsatt-personident with Papirsykmelding granted for Smregistrering and NAVIdent with rolle SYFO, PAPIRSYKMELDING and EGEN_ANSATT`() {
+        mockAdRolle(
+            graphApiConsumer = graphApiConsumerMock,
+            veilederIdent = VEILEDER_ID,
+            innvilget = INNVILG,
+            adRolleList = arrayOf(adRoller.SYFO, adRoller.PAPIRSYKMELDING, adRoller.EGEN_ANSATT),
+        )
+
+        val headers: MultiValueMap<String, String> = LinkedMultiValueMap()
+        headers.add(NAV_PERSONIDENT_HEADER, ERIK_EGENANSATT_BRUKER)
+
+        val response = tilgangController.accessToPersonIdentWithPapirsykmelding(headers)
+        assertAccessOk(response)
+    }
+
+    private fun assertAccessOk(response: ResponseEntity<*>) {
+        assertEquals(200, response.statusCodeValue)
+        val tilgang = response.body as Tilgang
+        assertTrue(tilgang.harTilgang)
+    }
+
+    private fun assertAccessDenied(response: ResponseEntity<*>, begrunnelse: String) {
+        assertEquals(403, response.statusCodeValue)
+        val tilgang = response.body as Tilgang
+        assertFalse(tilgang.harTilgang)
+        assertEquals(begrunnelse, tilgang.begrunnelse)
+    }
+
+    companion object {
+        private const val INNVILG = true
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -9,17 +9,23 @@ server:
   servlet:
     context-path: /syfo-tilgangskontroll
 
+smregistrering.client.id: "smregistrering-backend-client-id"
+
+preauthorized:
+  smregistrering: "{\"name\":\"dev-fss:teamsykmelding:smregistrering-backend\",\"clientId\":\"${smregistrering.client.id}\"}"
+
 azure:
   app:
     client:
       id: "1345678"
       secret: "secret"
+    pre:
+      authorized:
+        apps: "[${preauthorized.smregistrering}]"
   openid:
     config:
       token:
         endpoint: "https://login.microsoftonline.com/id/oauth2/v2.0/token"
-
-smregistrering.client.id: "smregistrering"
 
 axsys.url: "http://test-axsys"
 graphapi.url: "https://graph.microsoft.com"
@@ -37,5 +43,6 @@ role.nasjonal.id: "nasjonalId"
 role.utvidbar.nasjonal.id: "utvidbarNasjonalId"
 role.regional.id: "regionalId"
 role.utvidbar.regional.id: "utvidvarRegionalId"
+role.papirsykmelding.id: "papirsykmeldingId"
 
 AZURE_APP_PRE_AUTHORIZED_APPS: "[]"


### PR DESCRIPTION
Add new endpoint with Tilgangskontroll for Papirsykmelding. Consuming application is granted access to PersonIdent if the consuming application is Smregistrering-backend and it is requesting access on behalf of a VeilederIdent with the AD-role 0000-GA-papirsykmelding. 