### PR TITLE
Remove Begrunnelse from Tilgang DTO

### DIFF
--- a/src/main/kotlin/no/nav/syfo/tilgang/Tilgang.kt
+++ b/src/main/kotlin/no/nav/syfo/tilgang/Tilgang.kt
@@ -4,5 +4,4 @@ import java.io.Serializable
 
 data class Tilgang(
     val harTilgang: Boolean = false,
-    val begrunnelse: String? = null,
 ) : Serializable

--- a/src/main/kotlin/no/nav/syfo/tilgang/TilgangService.kt
+++ b/src/main/kotlin/no/nav/syfo/tilgang/TilgangService.kt
@@ -45,13 +45,11 @@ class TilgangService @Autowired constructor(
         if (!harTilgangTilTjenesten(veilederId)) {
             return Tilgang(
                 harTilgang = false,
-                begrunnelse = adRoller.SYFO.name
             )
         }
         if (!geografiskTilgangService.harGeografiskTilgang(veilederId, brukerFnr)) {
             return Tilgang(
                 harTilgang = false,
-                begrunnelse = GEOGRAFISK
             )
         }
         val personIdentNumber = PersonIdentNumber(brukerFnr)
@@ -65,18 +63,15 @@ class TilgangService @Autowired constructor(
         ) {
             return Tilgang(
                 harTilgang = false,
-                begrunnelse = adRoller.KODE6.name
             )
         } else if (pdlConsumer.isKode7(pdlPerson) && !harTilgangTilKode7(veilederId)) {
             return Tilgang(
                 harTilgang = false,
-                begrunnelse = adRoller.KODE7.name
             )
         }
         return if (skjermedePersonerPipConsumer.erSkjermet(brukerFnr) && !harTilgangTilEgenAnsatt(veilederId)) {
             return Tilgang(
                 harTilgang = false,
-                begrunnelse = adRoller.EGEN_ANSATT.name
             )
         } else Tilgang(harTilgang = true)
     }
@@ -99,7 +94,6 @@ class TilgangService @Autowired constructor(
             )
         } else Tilgang(
             harTilgang = false,
-            begrunnelse = adRoller.PAPIRSYKMELDING.name
         )
     }
 
@@ -109,7 +103,6 @@ class TilgangService @Autowired constructor(
             harTilgang = true
         ) else Tilgang(
             harTilgang = false,
-            begrunnelse = adRoller.SYFO.name
         )
     }
 
@@ -117,11 +110,9 @@ class TilgangService @Autowired constructor(
     fun sjekkTilgangTilEnhet(veilederId: String, enhet: String): Tilgang {
         if (!harTilgangTilSykefravaersoppfoelging(veilederId)) return Tilgang(
             harTilgang = false,
-            begrunnelse = adRoller.SYFO.name
         )
         return if (!harTilgangTilEnhet(veilederId, enhet)) Tilgang(
             harTilgang = false,
-            begrunnelse = ENHET
         ) else Tilgang(
             harTilgang = true
         )

--- a/src/test/kotlin/no/nav/syfo/api/AccessToRessursViaAzure2ComponentTest.kt
+++ b/src/test/kotlin/no/nav/syfo/api/AccessToRessursViaAzure2ComponentTest.kt
@@ -25,7 +25,6 @@ import no.nav.syfo.testhelper.generateAdressebeskyttelse
 import no.nav.syfo.testhelper.generatePdlHentPerson
 import no.nav.syfo.tilgang.Tilgang
 import no.nav.syfo.tilgang.TilgangController
-import no.nav.syfo.tilgang.TilgangService.Companion.ENHET
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.*
@@ -126,7 +125,7 @@ class AccessToRessursViaAzure2ComponentTest {
     fun accessToSYFODenied() {
         mockAdRolle(graphApiConsumerMock, VEILEDER_ID, NEKT, adRoller.SYFO)
         val response = tilgangController.accessToSYFOViaAzure()
-        assertAccessDenied(response, adRoller.SYFO.name)
+        assertAccessDenied(response)
     }
 
     @Test
@@ -145,7 +144,7 @@ class AccessToRessursViaAzure2ComponentTest {
         val headers: MultiValueMap<String, String> = LinkedMultiValueMap()
         headers.add(NAV_PERSONIDENT_HEADER, BENGT_KODE6_BRUKER)
         val response = tilgangController.accessToPersonIdentViaAzure(headers)
-        assertAccessDenied(response, adRoller.KODE6.name)
+        assertAccessDenied(response)
     }
 
     @Test
@@ -155,7 +154,7 @@ class AccessToRessursViaAzure2ComponentTest {
         val headers: MultiValueMap<String, String> = LinkedMultiValueMap()
         headers.add(NAV_PERSONIDENT_HEADER, BENGT_KODE6_BRUKER)
         val response = tilgangController.accessToPersonIdentViaAzure(headers)
-        assertAccessDenied(response, adRoller.KODE6.name)
+        assertAccessDenied(response)
     }
 
     @Test
@@ -178,7 +177,7 @@ class AccessToRessursViaAzure2ComponentTest {
         val headers: MultiValueMap<String, String> = LinkedMultiValueMap()
         headers.add(NAV_PERSONIDENT_HEADER, BIRTE_KODE7_BRUKER)
         val response = tilgangController.accessToPersonIdentViaAzure(headers)
-        assertAccessDenied(response, adRoller.KODE7.name)
+        assertAccessDenied(response)
     }
 
     @Test
@@ -196,7 +195,7 @@ class AccessToRessursViaAzure2ComponentTest {
         val headers: MultiValueMap<String, String> = LinkedMultiValueMap()
         headers.add(NAV_PERSONIDENT_HEADER, ERIK_EGENANSATT_BRUKER)
         val response = tilgangController.accessToPersonIdentViaAzure(headers)
-        assertAccessDenied(response, adRoller.EGEN_ANSATT.name)
+        assertAccessDenied(response)
     }
 
     @Test
@@ -219,7 +218,7 @@ class AccessToRessursViaAzure2ComponentTest {
     fun `access to enhet denied`() {
         mockAdRolle(graphApiConsumerMock, VEILEDER_ID, INNVILG, adRoller.SYFO)
         val response = tilgangController.accessToEnhet(NAV_ENHETID_3)
-        assertAccessDenied(response, ENHET)
+        assertAccessDenied(response)
     }
 
     @Test
@@ -266,11 +265,10 @@ class AccessToRessursViaAzure2ComponentTest {
         assertTrue(tilgang.harTilgang)
     }
 
-    private fun assertAccessDenied(response: ResponseEntity<*>, begrunnelse: String) {
+    private fun assertAccessDenied(response: ResponseEntity<*>) {
         assertEquals(HTTP_STATUS_FORBIDDEN.toLong(), response.statusCodeValue.toLong())
         val tilgang = response.body as Tilgang
         assertFalse(tilgang.harTilgang)
-        assertEquals(begrunnelse, tilgang.begrunnelse)
     }
 
     companion object {

--- a/src/test/kotlin/no/nav/syfo/api/PapirsykmeldingTilgangTest.kt
+++ b/src/test/kotlin/no/nav/syfo/api/PapirsykmeldingTilgangTest.kt
@@ -143,7 +143,7 @@ class PapirsykmeldingTilgangTest {
         headers.add(NAV_PERSONIDENT_HEADER, BJARNE_BRUKER)
 
         val response = tilgangController.accessToPersonIdentWithPapirsykmelding(headers)
-        assertAccessDenied(response, adRoller.PAPIRSYKMELDING.name)
+        assertAccessDenied(response)
     }
 
     @Test
@@ -159,7 +159,7 @@ class PapirsykmeldingTilgangTest {
         headers.add(NAV_PERSONIDENT_HEADER, BJARNE_BRUKER)
 
         val response = tilgangController.accessToPersonIdentWithPapirsykmelding(headers)
-        assertAccessDenied(response, adRoller.PAPIRSYKMELDING.name)
+        assertAccessDenied(response)
     }
 
     @Test
@@ -176,7 +176,7 @@ class PapirsykmeldingTilgangTest {
         headers.add(NAV_PERSONIDENT_HEADER, BENGT_KODE6_BRUKER)
 
         val response = tilgangController.accessToPersonIdentWithPapirsykmelding(headers)
-        assertAccessDenied(response, adRoller.KODE6.name)
+        assertAccessDenied(response)
     }
 
     @Test
@@ -213,7 +213,7 @@ class PapirsykmeldingTilgangTest {
         headers.add(NAV_PERSONIDENT_HEADER, BIRTE_KODE7_BRUKER)
 
         val response = tilgangController.accessToPersonIdentWithPapirsykmelding(headers)
-        assertAccessDenied(response, adRoller.KODE7.name)
+        assertAccessDenied(response)
     }
 
     @Test
@@ -245,7 +245,7 @@ class PapirsykmeldingTilgangTest {
         headers.add(NAV_PERSONIDENT_HEADER, ERIK_EGENANSATT_BRUKER)
 
         val response = tilgangController.accessToPersonIdentWithPapirsykmelding(headers)
-        assertAccessDenied(response, adRoller.EGEN_ANSATT.name)
+        assertAccessDenied(response)
     }
 
     @Test
@@ -270,11 +270,10 @@ class PapirsykmeldingTilgangTest {
         assertTrue(tilgang.harTilgang)
     }
 
-    private fun assertAccessDenied(response: ResponseEntity<*>, begrunnelse: String) {
+    private fun assertAccessDenied(response: ResponseEntity<*>) {
         assertEquals(403, response.statusCodeValue)
         val tilgang = response.body as Tilgang
         assertFalse(tilgang.harTilgang)
-        assertEquals(begrunnelse, tilgang.begrunnelse)
     }
 
     companion object {


### PR DESCRIPTION
Remove Begrunnelse from DTO object exposed to external consumers. It is removed to minimize the amount of information exposed externally about a Person and why a NavIdent is not granted access to the person, Begrunnelse has been removed from code in all consuming clients and can therefore be safely be removed.