### PR TITLE
Bump Spring Boot to latest version

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -115,14 +115,6 @@ spec:
       - kvPath: /kv/preprod/fss/syfo-tilgangskontroll/default
         mountPath: /var/run/secrets/nais.io/vault
   env:
-    - name: APP_NAME
-      value: "syfo-tilgangskontroll"
-    - name: APPDYNAMICS_CONTROLLER_HOST_NAME
-      value: appdynamics.adeo.no
-    - name: APPDYNAMICS_CONTROLLER_PORT
-      value: "443"
-    - name: APPDYNAMICS_CONTROLLER_SSL_ENABLED
-      value: "true"
     - name: SMREGISTRERING_CLIENT_ID
       value: "3936bfbe-f658-4eab-a0e4-0222fc730d67"
     - name: AXSYS_URL

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -115,14 +115,6 @@ spec:
       - kvPath: /kv/prod/fss/syfo-tilgangskontroll/default
         mountPath: /var/run/secrets/nais.io/vault
   env:
-    - name: APP_NAME
-      value: "syfo-tilgangskontroll"
-    - name: APPDYNAMICS_CONTROLLER_HOST_NAME
-      value: appdynamics.adeo.no
-    - name: APPDYNAMICS_CONTROLLER_PORT
-      value: "443"
-    - name: APPDYNAMICS_CONTROLLER_SSL_ENABLED
-      value: "true"
     - name: SMREGISTRERING_CLIENT_ID
       value: "7dbaa882-8730-4ed2-97fb-42ca08b7ea29"
     - name: AXSYS_URL

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM navikt/java:11-appdynamics
-ENV APPD_ENABLED=true
+FROM navikt/java:11
 
 COPY build/libs/app.jar app.jar
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ val logbackSyslog4jVersion = "1.0.0"
 plugins {
     kotlin("jvm") version "1.6.10"
     id("org.jetbrains.kotlin.plugin.allopen") version "1.6.10"
-    id("org.springframework.boot") version "2.4.13"
+    id("org.springframework.boot") version "2.6.6"
     id("io.spring.dependency-management") version "1.0.11.RELEASE"
     id("com.github.johnrengelman.shadow") version "7.1.1"
     id("org.jlleitschuh.gradle.ktlint") version "10.2.1"


### PR DESCRIPTION
Remove appdynamics setup causing issues with spring-boot-starter-data-redis with Spring Boot >= 2.5.0.