### PR TITLE
Remove syfosoknad from access policy

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -90,9 +90,6 @@ spec:
         - application: spinnsyn-backend
           namespace: flex
           cluster: dev-gcp
-        - application: syfosoknad
-          namespace: flex
-          cluster: dev-fss
         - application: sykepengesoknad-backend
           namespace: flex
           cluster: dev-gcp

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -90,9 +90,6 @@ spec:
         - application: spinnsyn-backend
           namespace: flex
           cluster: prod-gcp
-        - application: syfosoknad
-          namespace: flex
-          cluster: prod-fss
         - application: sykepengesoknad-backend
           namespace: flex
           cluster: prod-gcp


### PR DESCRIPTION
Syfosoknad no longer exsists and is removed from access policy.