### PR TITLE
Remove access of Syfomoteadmin to API

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -72,9 +72,6 @@ spec:
         - application: syfomodiaperson
           namespace: teamsykefravr
           cluster: dev-fss
-        - application: syfomoteadmin
-          namespace: teamsykefravr
-          cluster: dev-fss
         - application: syfooversiktsrv
           namespace: teamsykefravr
           cluster: dev-gcp

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -72,9 +72,6 @@ spec:
         - application: syfomodiaperson
           namespace: teamsykefravr
           cluster: prod-fss
-        - application: syfomoteadmin
-          namespace: teamsykefravr
-          cluster: prod-fss
         - application: syfooversiktsrv
           namespace: teamsykefravr
           cluster: prod-gcp


### PR DESCRIPTION
Syfomoteadmin is no longer in use and its access is therefore removed.