### PR TITLE
syfosmregister migrert til gcp

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -98,9 +98,6 @@ spec:
           cluster: dev-fss
         - application: syfosmregister
           namespace: teamsykmelding
-          cluster: dev-fss
-        - application: syfosmregister
-          namespace: teamsykmelding
           cluster: dev-gcp
   azure:
     application:

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -98,9 +98,6 @@ spec:
           cluster: prod-fss
         - application: syfosmregister
           namespace: teamsykmelding
-          cluster: prod-fss
-        - application: syfosmregister
-          namespace: teamsykmelding
           cluster: prod-gcp
   azure:
     application:


### PR DESCRIPTION
syfosmregister kjører fortsatt på fss, men det er bare trafikken fra syfomodiaperson som generer kall til tilgangskontroll, og syfomodiaperson bruker nå syfosmregister på gcp.