### PR TITLE
Add filter to only get "our" AD groups from graph API

### DIFF
--- a/src/main/kotlin/no/nav/syfo/domain/AdRoller.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/AdRoller.kt
@@ -66,4 +66,18 @@ class AdRoller(
         id = papirsykmeldingId,
         rolle = "0000-GA-papirsykmelding",
     )
+
+    fun getIdList(): List<String> {
+        return listOf(
+            KODE6.id,
+            KODE7.id,
+            SYFO.id,
+            EGEN_ANSATT.id,
+            NASJONAL.id,
+            UTVIDBAR_TIL_NASJONAL.id,
+            REGIONAL.id,
+            UTVIDBAR_TIL_REGIONAL.id,
+            PAPIRSYKMELDING.id,
+        )
+    }
 }


### PR DESCRIPTION
Avoid pagination of the result from graph api when users have access to more than 100 groups. We need header "ConsistencyLevel: eventual" and param "count=true" to be able to use the filter we want.

Co-authored-by: June Henriksen <june.henriksen2@nav.no>