### PR TITLE
Bugfix redis exporter config

### DIFF
--- a/.nais/redis-config.yaml
+++ b/.nais/redis-config.yaml
@@ -59,6 +59,6 @@ spec:
     - name: REDIS_EXPORTER_LOG_FORMAT
       value: json
   accessPolicy:
-    inbound:
+    outbound:
       rules:
         - application: syfo-tilgangskontroll-redis


### PR DESCRIPTION
Får ikke opp noe metrics i Grafana for redis-cachen på GCP. Tror årsaken er en bug i redis-exporter-config'en.